### PR TITLE
🧹 remove redundant subprocess import in ci/bootstrap.py

### DIFF
--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -29,8 +29,6 @@ def exec_in_env():
     else:
         bin_path = join(env_path, "bin")
     if not exists(env_path):
-        import subprocess
-
         print("Making bootstrap env in: {0} ...".format(env_path))
         try:
             check_call([sys.executable, "-m", "venv", env_path])


### PR DESCRIPTION
This commit removes an unnecessary local `import subprocess` inside the `exec_in_env` function of `ci/bootstrap.py`. Since `subprocess` is already imported at the top level of the module, this local import was redundant and did not contribute to the code's functionality or clarity.

🎯 **What:** Removed `import subprocess` from line 32 in `ci/bootstrap.py`. 💡 **Why:** Simplifies the code and improves readability by removing redundant imports. ✅ **Verification:**
- Ran `ruff check ci/bootstrap.py` (passed).
- Ran `python ci/bootstrap.py` (verified it still executes and creates the bootstrap environment).
- Ran project-wide lint check `ruff check .` (passed).
- Ran full test suite with `pytest` (passed). ✨ **Result:** Cleaner and more maintainable bootstrap script.